### PR TITLE
chore: Bump version to 0.1.2 after successful PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "philoch-bib-sdk"
-version = "0.1.1-rc1"
+version = "0.1.2"
 description = "Standard development kit for the Philosophie Bibliography project"
 authors = [
     {name = "Luis Alejandro Bordo García", email = "luis.bordo@philosophie.ch"}


### PR DESCRIPTION
This PR updates the project version to 0.1.2 following a successful publish to PyPI.