### PR TITLE
Refactor bibkey handling in journal volume number index

### DIFF
--- a/philoch_bib_sdk/converters/plaintext/bibitem/bibkey_parser.py
+++ b/philoch_bib_sdk/converters/plaintext/bibitem/bibkey_parser.py
@@ -142,3 +142,17 @@ def parse_bibkey(text: str) -> Ok[BibKeyAttr] | Err:
             error_type="BibkeyError",
             error_trace=f"{traceback.format_exc()}",
         )
+
+
+def hard_parse_bibkey(text: str) -> BibKeyAttr:
+    """
+    Hard parse a bibkey, without any error handling.
+    This is used for testing purposes only.
+    """
+
+    bibkey_parsed = parse_bibkey(text)
+
+    if isinstance(bibkey_parsed, Err):
+        raise ValueError(f"Could not hard parse '{text}' as bibkey: {bibkey_parsed.message}")
+
+    return bibkey_parsed.out

--- a/philoch_bib_sdk/logic/functions/journal_article_matcher.py
+++ b/philoch_bib_sdk/logic/functions/journal_article_matcher.py
@@ -1,6 +1,6 @@
 from typing import Callable, Dict, Tuple
 from philoch_bib_sdk.converters.plaintext.journal.formatter import format_journal
-from philoch_bib_sdk.logic.models import BibItem
+from philoch_bib_sdk.logic.models import BibItem, BibKeyAttr
 
 
 type TJournalName = str
@@ -12,10 +12,12 @@ type TNumber = str
 type TBibkey = str
 
 
-type TJournalBibkeyIndex = Dict[Tuple[TJournalName, TVolume, TNumber], TBibkey]  # (journal, volume, number)  # bibkey
+type TJournalBibkeyIndex = Dict[
+    Tuple[TJournalName, TVolume, TNumber], BibKeyAttr
+]  # (journal, volume, number)  # bibkey
 
 
-def get_bibkey_by_journal_volume_number(index: TJournalBibkeyIndex, subject: BibItem) -> TBibkey:
+def get_bibkey_by_journal_volume_number(index: TJournalBibkeyIndex, subject: BibItem) -> BibKeyAttr:
     """
     Simple lookup of a Bibitem on an index for its bibkey, via the combination (journal_name, volume, number). Fails if any of the three fields are missing.
     """


### PR DESCRIPTION
Update the handling of bibkeys in the journal volume number index to improve parsing and error management. This includes changes to data types and the introduction of a hard parsing function for testing purposes.